### PR TITLE
Fix wrong word

### DIFF
--- a/src/vinnie/Scene4.hx
+++ b/src/vinnie/Scene4.hx
@@ -44,7 +44,7 @@ class Scene4 extends Scene
             ),
             speak.bind(
                 Assets.partyBots2,
-                "The key is hidden to have been hidden with the ancient Tibetan handkerchief.",
+                "The key is rumoured to have been hidden with the ancient Tibetan handkerchief.",
                 "Where should I start looking?"
             ),
             function()


### PR DESCRIPTION
Change "hidden" to "rumoured", to be consistent with voice line

(British spelling was chosen because Troy Scott was Canadian, but I haven't checked against the original game)